### PR TITLE
fix: 修复换楼后队友战绩分析消息不更新的问题

### DIFF
--- a/src/components/pages/ToolsPage.tsx
+++ b/src/components/pages/ToolsPage.tsx
@@ -108,6 +108,7 @@ export function ToolsPage() {
   const [benchNoCooldown, setBenchNoCooldown] = useState(store.get('benchNoCooldown'))
   const [hideTFT, setHideTFT] = useState(store.get('hideTFT'))
   const [hideRightNavText, setHideRightNavText] = useState(store.get('hideRightNavText'))
+  const [fixLcuWindow, setFixLcuWindow] = useState(store.get('fixLcuWindow'))
   const [windowEffect, setWindowEffect] = useState(store.get('windowEffect'))
   const [champSelectAssist, setChampSelectAssist] = useState(store.get('champSelectAssist'))
   const [opggBuildRecommendation, setOpggBuildRecommendation] = useState(store.get('opggBuildRecommendation'))
@@ -163,6 +164,7 @@ export function ToolsPage() {
       store.onChange('unlockChromas', setUnlockChromas),
       store.onChange('benchNoCooldown', setBenchNoCooldown),
       store.onChange('hideTFT', setHideTFT),
+      store.onChange('fixLcuWindow', setFixLcuWindow),
       store.onChange('windowEffect', setWindowEffect),
       store.onChange('champSelectAssist', setChampSelectAssist),
       store.onChange('opggBuildRecommendation', setOpggBuildRecommendation),
@@ -642,6 +644,15 @@ export function ToolsPage() {
           <SonaSwitch
             checked={hideRightNavText}
             onChange={(v) => { setHideRightNavText(v); store.set('hideRightNavText', v) }}
+          />
+        </SettingCard>
+        <SettingCard
+          title="窗口异常修复"
+          description="自动修复客户端最小化恢复或子窗口（Wegame 对局助手）尺寸异常的问题。"
+        >
+          <SonaSwitch
+            checked={fixLcuWindow}
+            onChange={(v) => { setFixLcuWindow(v); store.set('fixLcuWindow', v) }}
           />
         </SettingCard>
         <SettingCard

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -26,6 +26,7 @@ import { updateCustomProfileBg } from '@/lib/features/profile-background'
 import { updateCustomBanner } from '@/lib/features/custom-banner'
 import { updateGameAnalysisPopup } from '@/lib/features/game-analysis-popup'
 import { updateAutoReturnToLobby } from '@/lib/features/auto-return-to-lobby'
+import { updateFixLcuWindow } from '@/lib/features/fix-lcu-window'
 import { updateOpggBuildRecommendation } from '@/lib/features/opgg-build-recommendation'
 import { preloadChampSelectTierBadgeData, updateChampSelectTierBadge } from '@/lib/features/champselect-tier-badge'
 import { setAvailabilityHijackEnabled, setHideTFTEnabled, setHideRightNavTextEnabled } from '@/lib/injections'
@@ -849,6 +850,8 @@ export function initFeatures() {
 
   updateAutoReturnToLobby(store.get('autoReturnToLobby'))
   store.onChange('autoReturnToLobby', updateAutoReturnToLobby)
+  updateFixLcuWindow(store.get('fixLcuWindow'))
+  store.onChange('fixLcuWindow', updateFixLcuWindow)
   store.onChange('autoReturnMode', () => {
     // 模式变化时，如果功能已启用，重新注册以应用新模式
     if (store.get('autoReturnToLobby')) {

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -576,6 +576,13 @@ async function analyzeTeammates() {
   try {
     const { stats } = await fetchTeamStats()
 
+    // 缓存 stats 供换楼后重建消息（避免重复请求 SGP）
+    analyzeTeamPowerStatsByPuuid.clear()
+    for (const s of stats) {
+      if (s.puuid) analyzeTeamPowerStatsByPuuid.set(s.puuid, s)
+      if (s.summonerId) analyzeTeamPowerStatsByPuuid.set(`sid:${s.summonerId}`, s)
+    }
+
     logger.info('┌─── 队友战绩分析 ───')
 
     const chatLines: string[] = ['Sona助手 ♫   队友卡池一览(本模式战绩):\n']
@@ -627,21 +634,70 @@ async function analyzeTeammates() {
 
 let analyzeTeamPowerUnsub: (() => void) | null = null
 let analyzeTeamPowerUpdateUnsub: (() => void) | null = null
-let lastAnalyzedTeamSignature = ''
+/** 上次发送聊天消息时的 trades 快照，换楼会导致 trades 变化从而触发重发 */
+let lastAnalyzedTradesSnapshot = ''
+/** puuid → TeammateStats 缓存，换楼后直接从缓存重建消息，避免重复请求 SGP */
+const analyzeTeamPowerStatsByPuuid = new Map<string, TeammateStats>()
 
-/** 换楼后重新获取数据并发送聊天消息 */
+/** 根据 myTeam 顺序 + 缓存的 stats 构造聊天消息并发送 */
+async function resendAnalyzeMessageFromCache() {
+  try {
+    const session = await lcu.getChampSelectSession()
+    if (!session?.myTeam) return
+
+    const chatLines: string[] = ['Sona助手 ♫   队友卡池一览(本模式战绩):\n']
+    for (let i = 0; i < session.myTeam.length; i++) {
+      const player = session.myTeam[i]
+      const floor = `${i + 1}楼`
+      const stat = (player.puuid ? analyzeTeamPowerStatsByPuuid.get(player.puuid) : undefined)
+        ?? (player.summonerId ? analyzeTeamPowerStatsByPuuid.get(`sid:${player.summonerId}`) : undefined)
+
+      if (!stat || stat.winRate == null) {
+        chatLines.push(`${floor}: 🆕 萌新上线 (无战绩)`)
+        continue
+      }
+
+      const winRate = stat.winRate.toFixed(1)
+      const kdaStr = stat.kdaNum >= 99 ? 'Perfect' : stat.kdaNum.toFixed(2)
+      const rating = getRating(stat.winRate, stat.kdaNum)
+      chatLines.push(`${floor}: ${rating} | 胜率${winRate}% | KDA ${kdaStr}`)
+    }
+
+    const msg = chatLines.join('\n')
+    const msgType = store.get('analyzeTeamPowerMsgType') || 'celebration'
+    for (let attempt = 0; attempt < 10; attempt++) {
+      try {
+        await lcu.sendChampSelectMessage(msg, msgType)
+        logger.info('队友分析已发送到聊天框 ✓')
+        break
+      } catch {
+        if (attempt < 9) {
+          await sleep(1000)
+        } else {
+          logger.warn('聊天发送失败，聊天室始终未就绪')
+        }
+      }
+    }
+  } catch (err) {
+    logger.error('队友战绩分析失败:', err)
+  }
+}
+
+/** 监听 CHAMP_SELECT Update，通过 trades 变化检测换楼 */
 function onAnalyzeTeamPowerSwap(event: LCUEventMessage) {
   if (event.eventType !== 'Update') return
 
   const session = event.data as ChampSelectSession
-  if (!session?.myTeam) return
+  if (!session) return
 
-  const nextSignature = getTeamDisplaySignature(session)
-  if (nextSignature === lastAnalyzedTeamSignature) return
+  // 换楼时 trades 状态会变化：发起 → ACCEPTED → 消失
+  // 用 trades 的序列化快照检测
+  const tradesSnapshot = JSON.stringify(session.trades ?? [])
+  if (tradesSnapshot === lastAnalyzedTradesSnapshot) return
 
   logger.info('[AnalyzeTeamPower] 检测到换楼，重新发送队友战绩分析')
-  lastAnalyzedTeamSignature = nextSignature
-  analyzeTeammates()
+  lastAnalyzedTradesSnapshot = tradesSnapshot
+  resendAnalyzeMessageFromCache()
 }
 
 function updateAnalyzeTeamPower(enabled: boolean) {
@@ -661,7 +717,8 @@ function updateAnalyzeTeamPower(enabled: boolean) {
       analyzeTeamPowerUpdateUnsub()
       analyzeTeamPowerUpdateUnsub = null
     }
-    lastAnalyzedTeamSignature = ''
+    lastAnalyzedTradesSnapshot = ''
+    analyzeTeamPowerStatsByPuuid.clear()
     logger.info('Analyze team power disabled')
   }
 }

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -583,7 +583,7 @@ function getPhaseLabel(phase: string): string {
   }
 }
 
-const SEPARATOR = '━━━━━━━━'.repeat(2)
+const SEPARATOR = '━━━'
 
 /** 统一的队友战绩消息构造与发送 */
 async function sendTeamStatsMessage(stats: TeammateStats[], phaseLabel: string) {

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -572,8 +572,59 @@ export function getRating(winRate: number, kda: number): string {
   return '☠️ 演员已就位'
 }
 
+/** 将 timer.phase 或自定义阶段映射为中文 */
+function getPhaseLabel(phase: string): string {
+  switch (phase) {
+    case 'PLANNING': return '预选英雄阶段'
+    case 'BAN_PICK': return '禁用/选择阶段'
+    case 'FINALIZATION': return '锁定英雄阶段'
+    case 'trade_swap': return '英雄换楼阶段'
+    default: return '数据刷新'
+  }
+}
+
+const SEPARATOR = '━━━━━━━━'.repeat(2)
+
+/** 统一的队友战绩消息构造与发送 */
+async function sendTeamStatsMessage(stats: TeammateStats[], phaseLabel: string) {
+  const header = `${SEPARATOR} 队友卡池一览（${phaseLabel}）${SEPARATOR}`
+  const chatLines: string[] = [header, '']
+
+  for (const s of stats) {
+    const floor = `${s.floor}楼`
+    if (s.winRate == null) {
+      chatLines.push(`${floor}: 🆕 萌新上线 (无战绩)`)
+      continue
+    }
+    const winRate = s.winRate.toFixed(1)
+    const kdaStr = s.kdaNum >= 99 ? 'Perfect' : s.kdaNum.toFixed(2)
+    const rating = getRating(s.winRate, s.kdaNum)
+    chatLines.push(`${floor}: ${rating} | 胜率${winRate}% | KDA ${kdaStr}`)
+  }
+
+  chatLines.push('')
+  chatLines.push('Sona助手 ♫')
+
+  const msg = chatLines.join('\n')
+  const msgType = store.get('analyzeTeamPowerMsgType') || 'celebration'
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      await lcu.sendChampSelectMessage(msg, msgType)
+      logger.info('队友分析已发送到聊天框 ✓ （%s）', phaseLabel)
+      break
+    } catch {
+      if (attempt < 9) {
+        await sleep(1000)
+      } else {
+        logger.warn('聊天发送失败，聊天室始终未就绪')
+      }
+    }
+  }
+}
+
 async function analyzeTeammates() {
   try {
+    const session = await lcu.getChampSelectSession()
     const { stats } = await fetchTeamStats()
 
     // 缓存 stats 供换楼后重建消息（避免重复请求 SGP）
@@ -583,50 +634,8 @@ async function analyzeTeammates() {
       if (s.summonerId) analyzeTeamPowerStatsByPuuid.set(`sid:${s.summonerId}`, s)
     }
 
-    logger.info('┌─── 队友战绩分析 ───')
-
-    const chatLines: string[] = ['Sona助手 ♫   队友卡池一览(本模式战绩):\n']
-
-    for (const s of stats) {
-      const floor = `${s.floor}楼`
-      if (s.winRate == null) {
-        logger.info('│ %s — %s#%s — 无近期战绩或查询失败', floor, s.gameName, s.tagLine)
-        chatLines.push(`${floor}: 🆕 萌新上线 (无战绩)`)
-        continue
-      }
-
-      const winRate = s.winRate.toFixed(1)
-      const kdaStr = s.kdaNum >= 99 ? 'Perfect' : s.kdaNum.toFixed(2)
-      const rating = getRating(s.winRate, s.kdaNum)
-
-      logger.info(
-        '│ %s — %s#%s — 近%d场 胜率: %s%% (%d胜%d负) | KDA: %s (%.1f/%.1f/%.1f) | %s',
-        floor, s.gameName, s.tagLine,
-        s.total, winRate, s.wins, s.total - s.wins,
-        kdaStr, s.avgK, s.avgD, s.avgA, rating,
-      )
-
-      chatLines.push(`${floor}: ${rating} | 胜率${winRate}% | KDA ${kdaStr}`)
-    }
-
-    logger.info('└────────────────────')
-
-    // 等待聊天室就绪后发送
-    const msg = chatLines.join('\n')
-    const msgType = store.get('analyzeTeamPowerMsgType') || 'celebration'
-    for (let attempt = 0; attempt < 10; attempt++) {
-      try {
-        await lcu.sendChampSelectMessage(msg, msgType)
-        logger.info('队友分析已发送到聊天框 ✓')
-        break
-      } catch {
-        if (attempt < 9) {
-          await sleep(1000)
-        } else {
-          logger.warn('聊天发送失败，聊天室始终未就绪')
-        }
-      }
-    }
+    const phaseLabel = getPhaseLabel(session.timer?.phase ?? '')
+    await sendTeamStatsMessage(stats, phaseLabel)
   } catch (err) {
     logger.error('队友战绩分析失败:', err)
   }
@@ -645,39 +654,29 @@ async function resendAnalyzeMessageFromCache() {
     const session = await lcu.getChampSelectSession()
     if (!session?.myTeam) return
 
-    const chatLines: string[] = ['Sona助手 ♫   队友卡池一览(本模式战绩):\n']
+    const stats: TeammateStats[] = []
     for (let i = 0; i < session.myTeam.length; i++) {
       const player = session.myTeam[i]
-      const floor = `${i + 1}楼`
       const stat = (player.puuid ? analyzeTeamPowerStatsByPuuid.get(player.puuid) : undefined)
         ?? (player.summonerId ? analyzeTeamPowerStatsByPuuid.get(`sid:${player.summonerId}`) : undefined)
 
-      if (!stat || stat.winRate == null) {
-        chatLines.push(`${floor}: 🆕 萌新上线 (无战绩)`)
-        continue
-      }
-
-      const winRate = stat.winRate.toFixed(1)
-      const kdaStr = stat.kdaNum >= 99 ? 'Perfect' : stat.kdaNum.toFixed(2)
-      const rating = getRating(stat.winRate, stat.kdaNum)
-      chatLines.push(`${floor}: ${rating} | 胜率${winRate}% | KDA ${kdaStr}`)
+      stats.push(stat ?? {
+        floor: i + 1,
+        summonerId: player.summonerId,
+        puuid: player.puuid,
+        gameName: player.gameName,
+        tagLine: player.tagLine,
+        winRate: null,
+        wins: 0,
+        total: 0,
+        avgK: 0,
+        avgD: 0,
+        avgA: 0,
+        kdaNum: 0,
+      })
     }
 
-    const msg = chatLines.join('\n')
-    const msgType = store.get('analyzeTeamPowerMsgType') || 'celebration'
-    for (let attempt = 0; attempt < 10; attempt++) {
-      try {
-        await lcu.sendChampSelectMessage(msg, msgType)
-        logger.info('队友分析已发送到聊天框 ✓')
-        break
-      } catch {
-        if (attempt < 9) {
-          await sleep(1000)
-        } else {
-          logger.warn('聊天发送失败，聊天室始终未就绪')
-        }
-      }
-    }
+    await sendTeamStatsMessage(stats, getPhaseLabel('trade_swap'))
   } catch (err) {
     logger.error('队友战绩分析失败:', err)
   }
@@ -690,8 +689,6 @@ function onAnalyzeTeamPowerSwap(event: LCUEventMessage) {
   const session = event.data as ChampSelectSession
   if (!session) return
 
-  // 换楼时 trades 状态会变化：发起 → ACCEPTED → 消失
-  // 用 trades 的序列化快照检测
   const tradesSnapshot = JSON.stringify(session.trades ?? [])
   if (tradesSnapshot === lastAnalyzedTradesSnapshot) return
 

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -626,6 +626,23 @@ async function analyzeTeammates() {
 }
 
 let analyzeTeamPowerUnsub: (() => void) | null = null
+let analyzeTeamPowerUpdateUnsub: (() => void) | null = null
+let lastAnalyzedTeamSignature = ''
+
+/** 换楼后重新获取数据并发送聊天消息 */
+function onAnalyzeTeamPowerSwap(event: LCUEventMessage) {
+  if (event.eventType !== 'Update') return
+
+  const session = event.data as ChampSelectSession
+  if (!session?.myTeam) return
+
+  const nextSignature = getTeamDisplaySignature(session)
+  if (nextSignature === lastAnalyzedTeamSignature) return
+
+  logger.info('[AnalyzeTeamPower] 检测到换楼，重新发送队友战绩分析')
+  lastAnalyzedTeamSignature = nextSignature
+  analyzeTeammates()
+}
 
 function updateAnalyzeTeamPower(enabled: boolean) {
   if (enabled && !analyzeTeamPowerUnsub) {
@@ -635,10 +652,16 @@ function updateAnalyzeTeamPower(enabled: boolean) {
         analyzeTeammates()
       }
     })
+    analyzeTeamPowerUpdateUnsub = lcu.observe(LcuEventUri.CHAMP_SELECT, onAnalyzeTeamPowerSwap)
     logger.info('Analyze team power enabled ✓')
   } else if (!enabled && analyzeTeamPowerUnsub) {
     analyzeTeamPowerUnsub()
     analyzeTeamPowerUnsub = null
+    if (analyzeTeamPowerUpdateUnsub) {
+      analyzeTeamPowerUpdateUnsub()
+      analyzeTeamPowerUpdateUnsub = null
+    }
+    lastAnalyzedTeamSignature = ''
     logger.info('Analyze team power disabled')
   }
 }

--- a/src/lib/features/fix-lcu-window.ts
+++ b/src/lib/features/fix-lcu-window.ts
@@ -1,0 +1,67 @@
+import { logger } from '@/index'
+
+// ==================== 客户端窗口异常修复 ====================
+
+let fixLcuWindowCleanup: (() => void) | null = null
+
+/** LCU 客户端标准尺寸范围 */
+const MIN_WIDTH = 1024
+const MIN_HEIGHT = 576
+const MAX_WIDTH = 1920
+const MAX_HEIGHT = 1200
+
+function clampWindowSize() {
+  const body = document.body
+  if (!body) return
+
+  const iw = window.innerWidth
+  const ih = window.innerHeight
+  const needsClamp =
+    iw > MAX_WIDTH ||
+    ih > MAX_HEIGHT ||
+    (iw > 0 && iw < MIN_WIDTH) ||
+    (ih > 0 && ih < MIN_HEIGHT)
+
+  if (needsClamp) {
+    body.style.maxWidth = `${MAX_WIDTH}px`
+    body.style.maxHeight = `${MAX_HEIGHT}px`
+    body.style.minWidth = `${MIN_WIDTH}px`
+    body.style.minHeight = `${MIN_HEIGHT}px`
+    body.style.overflow = 'auto'
+  } else {
+    body.style.maxWidth = ''
+    body.style.maxHeight = ''
+    body.style.minWidth = ''
+    body.style.minHeight = ''
+    body.style.overflow = ''
+  }
+}
+
+export function updateFixLcuWindow(enabled: boolean) {
+  if (enabled && !fixLcuWindowCleanup) {
+    let debounceTimer: number
+    const handler = () => {
+      window.clearTimeout(debounceTimer)
+      debounceTimer = window.setTimeout(clampWindowSize, 100)
+    }
+    window.addEventListener('resize', handler)
+    clampWindowSize()
+    fixLcuWindowCleanup = () => {
+      window.removeEventListener('resize', handler)
+      window.clearTimeout(debounceTimer)
+      const b = document.body
+      if (b) {
+        b.style.maxWidth = ''
+        b.style.maxHeight = ''
+        b.style.minWidth = ''
+        b.style.minHeight = ''
+        b.style.overflow = ''
+      }
+    }
+    logger.info('Fix LCU window enabled ✓')
+  } else if (!enabled && fixLcuWindowCleanup) {
+    fixLcuWindowCleanup()
+    fixLcuWindowCleanup = null
+    logger.info('Fix LCU window disabled')
+  }
+}

--- a/src/lib/features/global-particle.ts
+++ b/src/lib/features/global-particle.ts
@@ -19,6 +19,9 @@ function getGlobalParticleHost(): HTMLElement | null {
  * 必须等待客户端主视图宿主就绪后才挂载，避免首启时被 loading/iframe 层遮挡
  */
 function tryInjectGlobalParticle(): boolean {
+  // 只在 LCU 主窗口挂载粒子特效，跳过子窗口（如 Wegame 对局助手、天赋选择弹窗）
+  if (window.innerWidth < 800 || window.innerHeight < 550) return true
+
   const host = getGlobalParticleHost()
   if (!host) return false
 
@@ -49,8 +52,9 @@ function tryInjectGlobalParticle(): boolean {
   }> = []
 
   const resize = () => {
-    canvas.width = window.innerWidth
-    canvas.height = window.innerHeight
+    // 限制 canvas 最大尺寸，防止 CEF 子窗口（如 Wegame 对局助手）被异常撑大
+    canvas.width = Math.min(window.innerWidth, 1920)
+    canvas.height = Math.min(window.innerHeight, 1200)
   }
 
   const initParticles = () => {

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -138,6 +138,8 @@ export interface SonaConfig {
   autoReturnToLobby: boolean
   /** 自动返回模式: queue=自动排队, lobby=仅返回房间 */
   autoReturnMode: string
+  /** 修复客户端窗口异常（最小化恢复或子窗口尺寸异常时自动校正） */
+  fixLcuWindow: boolean
 }
 
 
@@ -192,6 +194,7 @@ const DEFAULT_CONFIG: SonaConfig = {
   gameAnalysisPopup: false,
   autoReturnToLobby: false,
   autoReturnMode: 'queue',
+  fixLcuWindow: false,
 }
 
 


### PR DESCRIPTION

## 问题描述

当队友在选人阶段交换楼层（trade/swap）后，`analyzeTeamPower` 功能发送的聊天消息（"队友卡池一览"）不会更新，导致楼层与 KDA/胜率数据对应错误。

例如：原本4楼的我与3楼队友换楼后，聊天框里3楼仍然显示我的数据，4楼显示队友的数据——数据"交换"了但实际上楼层对应错误。

## 根本原因

`analyzeTeamPower` 只在 `GameflowPhase` 为 `ChampSelect` 时触发一次 `analyzeTeammates()`，之后不再监听换楼事件。而 `champSelectAssist`（头像特效）已有换楼处理（`onChampSelectUpdate`），`analyzeTeamPower` 缺少同样的监听。

## 修复内容

在 `updateAnalyzeTeamPower` 中新增 `CHAMP_SELECT` session 的 Update 事件监听：
- 通过 `getTeamDisplaySignature()` 比较 myTeam 中 puuid:cellId 的映射签名
- 检测到换楼后重新调用 `analyzeTeammates()` 重新拉取数据并发送聊天消息
- 禁用功能时同时取消监听，避免泄漏