### PR TITLE
Add pengu.yml for install manifest

### DIFF
--- a/pengu.yml
+++ b/pengu.yml
@@ -1,0 +1,15 @@
+id: sona
+name: Sona
+description: Client enhancement suite — champion select tools, OP.GG builds, match history and beautification.
+version: $package.version
+
+repo: https://github.com/WJZ-P/sona
+
+author:
+  name: WJZ-P
+  github: WJZ-P
+
+tags: [utility, ui, champ-select]
+
+install:
+  release: "sona-*.zip"


### PR DESCRIPTION
This manifest will be used for plugin installer in the new app hub.
Note that the `$package` object points to your `package.json`.